### PR TITLE
New Path containing extra annotation

### DIFF
--- a/example-k8s-app-dnd/deployment.yaml
+++ b/example-k8s-app-dnd/deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: example
+  name: example
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: example
+  template:
+    metadata:
+      labels:
+        app: example
+    spec:
+      containers:
+        - image: alpinelinux/darkhttpd
+          name: darkhttpd
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          containerPorts:
+            - name: http
+              protocol: TCP
+              containerPort: 8080
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: example-data-claim

--- a/example-k8s-app-dnd/kustomization.yaml
+++ b/example-k8s-app-dnd/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: lars-sandbox
+
+resources:
+  - deployment.yaml
+  - pvc.yaml
+  - service.yaml

--- a/example-k8s-app-dnd/pvc.yaml
+++ b/example-k8s-app-dnd/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  annotations:
+    apps.open-cluster-management.io/do-not-delete: 'true'
+  name: example-data-claim
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/example-k8s-app-dnd/service.yaml
+++ b/example-k8s-app-dnd/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: example
+  name: example
+spec:
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app: example
+  type: LoadBalancer

--- a/example-k8s-app/pvc.yaml
+++ b/example-k8s-app/pvc.yaml
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  annotations:
-    apps.open-cluster-management.io/do-not-delete: 'true'
   name: example-data-claim
 spec:
   accessModes:

--- a/example-k8s-app/pvc.yaml
+++ b/example-k8s-app/pvc.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  annotations:
+    apps.open-cluster-management.io/do-not-delete: 'true'
   name: example-data-claim
 spec:
   accessModes:


### PR DESCRIPTION
Description

Adding a new path containing the do-not-delete annotation in a resource yaml to allow deploymehnt with annotation already available.

Polarion test case:
https://polarion.engineering.redhat.com/polarion/#/project/RHACM4K/workitem?id=RHACM4K-16939

GitHub Ticket:
https://github.com/stolostron/acm-qe/issues/1454

ACM image:
2.6.0-DOWNSTREAM-2022-07-09-13-09-35
